### PR TITLE
Various improvements

### DIFF
--- a/background.js
+++ b/background.js
@@ -34,7 +34,7 @@ function modifyRequest(e) {
 browser.webRequest.onBeforeSendHeaders.addListener(
   modifyRequest,
   {
-    urls: ['<all_urls>'],
+    urls: ['http://*/*', 'https://*/*'],
     types: ['main_frame']
   },
   [ 'blocking' ]

--- a/background.js
+++ b/background.js
@@ -20,12 +20,13 @@ function getLang(languageCode) {
 }
 
 function modifyRequest(e) {
-  if (e.url.indexOf('google.') != -1 &&
-      e.url.indexOf('hl=' + langTag) == -1) {
-    e.url += (e.url.indexOf('?') != -1 ? '&' : '?') + 'hl=' + langTag;
-
+  let url = new URL(e.url);
+  const labels = url.hostname.split(".").reverse().slice(1, 3);
+  if (!url.searchParams.has('hl') &&
+    (labels.includes('google') || labels.includes('youtube'))) {
+    url.searchParams.append('hl', langTag);
     return {
-      redirectUrl: e.url
+      redirectUrl: url.toString()
     };
   }
 }

--- a/background.js
+++ b/background.js
@@ -1,13 +1,23 @@
-let langTag = 'en';
+let langTag = getLang(browser.i18n.getUILanguage()) || 'en';
+setLang();
 
-(async () => {
+async function setLang() {
   let al = await browser.i18n.getAcceptLanguages();
   al.some(l => {
-    if (l.length == 2) {
-      langTag = l;
+    if (lang = getLang(l)) {
+      return langTag = lang;
     }
   });
-})();
+}
+
+function getLang(languageCode) {
+  if (languageCode) {
+    const lang = languageCode.split('-')[0];
+    if (lang.length === 2) {
+      return lang;
+    }
+  }
+}
 
 function modifyRequest(e) {
   if (e.url.indexOf('google.') != -1 &&

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
   "permissions": [
     "webRequest",
     "webRequestBlocking",
-		"<all_urls>"
+    "<all_urls>"
   ],
   "manifest_version": 2
 }


### PR DESCRIPTION
Thanks for creating this extension!

----

This PR contains 3 improvements:

- Dashed language codes are accepted, e.g. `["en-US", "fr"]` will use `en`
  - It also falls back to using the UI language if no usable `Accept-Language` is found
- Requests are limited to `http`/`https`
- Proper URL handling
  - Extension triggers if 2nd or 3rd domain label is `google` or `youtube` (e.g. `google.com`, `google.co.uk`). Other Google domains exist, including `*.google` and `*.goog`, but AFAIK `hl` is not used on any of those.
  - `hl` parameter insertion now works reliably (e.g. https://groups.google.com/forum/#!overview)